### PR TITLE
Performance tweak: don't watch /deploy and /node_modules.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -234,7 +234,16 @@ var SolidusServer = function( options ){
 		var auth_regex = new RegExp( paths.auth, 'i' );
 
 		var watcher = this.watcher = chokidar.watch( paths.site, {
-			ignored: /^\./,
+			ignored: function( file_path ) {
+				// Ignore hidden files and directories
+				if( /[\/\\]\./.test( file_path ) ) return true;
+
+				// Ignore /deploy and /node_modules
+				var root = path.relative( paths.site, file_path ).split( /[\/\\]/ )[ 0 ];
+				if( root == 'deploy' || root == 'node_modules' ) return true;
+
+				return false;
+			},
 			ignoreInitial: true,
 			interval: 1000
 		});
@@ -277,7 +286,7 @@ var SolidusServer = function( options ){
 
 		server.close();
 		if( this.watcher ) this.watcher.close();
-		
+
 	};
 
 	// use "this" as "this" for all methods attached to "this"


### PR DESCRIPTION
Running a Solidus site inside a Vagrant virtual machine, hosted on a Windows machine is pretty slow (https://github.com/solidusjs/solidus-devbox/issues/6). The problem is with the slow folders sharing between the machines.

This pull request removes unnecessary files from Solidus' watch list, which seems to fix the problem (`node_modules` contains a lot of files, there's no need to watch those).
