### PR TITLE
properly escape windows paths

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -24,6 +24,11 @@ var cache = lru({
 	maxAge: MAX_RESOURCE_AGE
 });
 
+// escape backslashes in path for use in regex
+var escapePathForRegex = function( file_path ){
+	return file_path.replace( /(\\)/g, '\\\\' );
+};
+
 // rounds datetime to nearest 5 minutes (in the past)
 var getRoundedTime = function( datetime, round_by ){
 	var remainder = datetime % round_by;
@@ -326,7 +331,7 @@ var Page = function( page_path, options ){
 			return -layout_path.length;
 		});
 		var local_layout = _( layouts ).find( function( layout_path ){
-			var layout_regex = new RegExp( layout_path.replace( /layout\..+$/i, '' ), 'i' );
+			var layout_regex = new RegExp( escapePathForRegex( layout_path.replace( /layout\..+$/i, '' ) ), 'i' );
 			return layout_regex.test( page.path );
 		});
 		if( !local_layout ) return null;

--- a/lib/server.js
+++ b/lib/server.js
@@ -33,6 +33,16 @@ var Preprocessor = require('./preprocessor.js');
 var Redirect = require('./redirect.js');
 var Logger = require('./logger.js');
 
+// make the path into a Windows compatible path
+var deGlobifyPath = function( file_path ){
+	return file_path.replace( /(\/)/g, path.sep );
+};
+
+// escape backslashes in path for use in regex
+var escapePathForRegex = function( file_path ){
+	return file_path.replace( /(\\)/g, '\\\\' );
+};
+
 var SolidusServer = function( options ){
 
 	// properly inherit from EventEmitter part 1
@@ -138,6 +148,7 @@ var SolidusServer = function( options ){
 	this.setupViews = function(){
 
 		glob( paths.views +'/**/*.'+ DEFAULT_VIEW_EXTENSION, function( err, view_paths ){
+			view_paths = view_paths.map( deGlobifyPath );
 			async.each( view_paths, solidus_server.addView, function( err ){
 				solidus_server.emit('ready');
 			});
@@ -220,6 +231,7 @@ var SolidusServer = function( options ){
 	this.setupPreprocessors = function(){
 
 		glob( paths.preprocessors +'/**/*.js', function( err, preprocessor_paths ){
+			preprocessor_paths = preprocessor_paths.map( deGlobifyPath );
 			async.each( preprocessor_paths, solidus_server.addPreprocessor );
 		});
 
@@ -228,10 +240,10 @@ var SolidusServer = function( options ){
 	// watches preprocessors dir and adds/removes when necessary
 	this.watch = function(){
 
-		var view_regex = new RegExp( paths.views +'.+\.hbs', 'i' );
-		var preprocessor_regex = new RegExp( paths.preprocessors +'.+\.js', 'i' );
-		var redirects_regex = new RegExp( paths.redirects, 'i' );
-		var auth_regex = new RegExp( paths.auth, 'i' );
+		var view_regex = new RegExp( escapePathForRegex( paths.views ) +'.+\.hbs', 'i' );
+		var preprocessor_regex = new RegExp( escapePathForRegex( paths.preprocessors ) +'.+\.js', 'i' );
+		var redirects_regex = new RegExp( escapePathForRegex( paths.redirects ), 'i' );
+		var auth_regex = new RegExp( escapePathForRegex( paths.auth ), 'i' );
 
 		var watcher = this.watcher = chokidar.watch( paths.site, {
 			ignored: /^\./,


### PR DESCRIPTION
Windows uses `\` as its path separator by default, so anything passed through the native node.js `path` methods spits out an unexpectedly backslashy string. Luckily we can get around this problem by being as slash-nostic as possible. There were two basic steps in the final solution:
- Escape backslashes before passing strings to the `RegExp` constructor
- Convert file paths returned by `glob` into the appropriate OS-specific path (read: convert `/` to `path.sep`)
