### PR TITLE
reload workers when preprocessors change

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -7,12 +7,8 @@ var EventEmitter = require('events').EventEmitter;
 
 var _ = require('underscore');
 var workerFarm = require('worker-farm');
-var workers = workerFarm({
-	maxCallsPerWorker: 100,
-	maxConcurrentWorkers: 4,
-	maxConcurrentCallsPerWorker: -1,
-	maxCallTime: 1000
-}, require.resolve('./preprocessor_worker.js'));
+
+var workers;
 
 var Preprocessor = function( preprocessor_path, options ){
 
@@ -38,21 +34,27 @@ var Preprocessor = function( preprocessor_path, options ){
 
 	};
 
-	// update the source of the preprocessor
-	this.updateSource = function( callback ){
-
-		delete require.cache[this.path];
-		callback();
-
-	};
-
-	this.updateSource( function(){
-		preprocessor.emit( 'ready' );
-	});
-
 };
 
 // properly inherit from EventEmitter part 2
 util.inherits( Preprocessor, EventEmitter );
+
+Preprocessor.setWorkers = function(){
+	workers = workerFarm({
+		maxCallsPerWorker: 100,
+		maxConcurrentWorkers: 4,
+		maxConcurrentCallsPerWorker: -1,
+		maxCallTime: 1000
+	}, require.resolve('./preprocessor_worker.js'));
+};
+
+// destroy and re-initialize worker farm
+// this is used to update preprocessor modules in development
+Preprocessor.resetWorkers = function(){
+	workerFarm.end( workers );
+	Preprocessor.setWorkers();
+};
+
+Preprocessor.setWorkers();
 
 module.exports = Preprocessor;

--- a/lib/server.js
+++ b/lib/server.js
@@ -227,8 +227,7 @@ var SolidusServer = function( options ){
 	// updates the source of a preprocessor
 	this.updatePreprocessor = function( preprocessor_path ){
 
-		var path_to = path.relative( paths.preprocessors, preprocessor_path );
-		preprocessors[path_to].updateSource();
+		Preprocessor.resetWorkers();
 
 	};
 


### PR DESCRIPTION
By killing all the workers and restarting them, preprocessor code is properly reloaded.
