### PR TITLE
Load new helpers from helpers.js.

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -332,6 +332,7 @@ var Page = function( page_path, options ){
           'Last-Modified': getRoundedTime( Date.now(), MODIFIED_ROUND_TIME ).toUTCString()
         });
       }
+      context.helpers = server.site_helpers;
       if( options.json ) return res.json( context );
       res.expose( context, 'solidus.context', 'context' );
       server.logger.log( page.route +' served in '+ ( new Date - start_serve ) +'ms', 3 );

--- a/lib/server.js
+++ b/lib/server.js
@@ -73,7 +73,8 @@ var SolidusServer = function( options ){
     redirects: path.join( options.site_path, 'redirects.json' ),
     preprocessors: path.join( options.site_path, 'preprocessors' ),
     assets: path.join( options.site_path, 'assets' ),
-    notfound: path.join( options.site_path, 'views', '404.hbs' )
+    notfound: path.join( options.site_path, 'views', '404.hbs' ),
+    helpers: path.join( options.site_path, 'helpers.js' )
   };
 
   // set up collections
@@ -82,6 +83,7 @@ var SolidusServer = function( options ){
   var preprocessors = this.preprocessors = {};
   var layouts = this.layouts = [];
   var auth = this.auth = {};
+  var site_helpers = this.site_helpers = {};
 
   // set up express server
   var router = this.router = express();
@@ -266,6 +268,21 @@ var SolidusServer = function( options ){
 
   };
 
+  this.setupSiteHelpers = function() {
+    var site_helpers = {};
+
+    if (fs.existsSync(paths.helpers)) {
+      try {
+        delete require.cache[require.resolve(paths.helpers)];
+        site_helpers = require(paths.helpers);
+      } catch (err) {
+        return this.logger.log('Error: could not load ' + path.relative(paths.site, paths.helpers) + ': ' + err, 3);
+      }
+    }
+
+    this.site_helpers = site_helpers;
+  };
+
   // watches preprocessors dir and adds/removes when necessary
   this.watch = function(){
 
@@ -273,6 +290,7 @@ var SolidusServer = function( options ){
     var preprocessor_regex = new RegExp( escapePathForRegex( paths.preprocessors ) +'.+\.js', 'i' );
     var redirects_regex = new RegExp( escapePathForRegex( paths.redirects ), 'i' );
     var auth_regex = new RegExp( escapePathForRegex( paths.auth ), 'i' );
+    var helpers_regex = new RegExp( escapePathForRegex( paths.helpers ), 'i' );
 
     var watcher = this.watcher = chokidar.watch( paths.site, {
       ignored: function( file_path ) {
@@ -294,18 +312,21 @@ var SolidusServer = function( options ){
       else if( preprocessor_regex.test( file_path ) ) solidus_server.addPreprocessor( file_path );
       else if( redirects_regex.test( file_path ) ) solidus_server.setupRedirects();
       else if( auth_regex.test( file_path ) ) solidus_server.setupAuth();
+      else if( helpers_regex.test( file_path ) ) solidus_server.setupSiteHelpers();
     });
     watcher.on( 'unlink', function( file_path ){
       if( view_regex.test( file_path ) ) solidus_server.removeView( file_path );
       else if( preprocessor_regex.test( file_path ) ) solidus_server.removePreprocessor( file_path );
       else if( redirects_regex.test( file_path ) ) solidus_server.clearRedirects();
       else if( auth_regex.test( file_path ) ) solidus_server.clearAuth();
+      else if( helpers_regex.test( file_path ) ) solidus_server.setupSiteHelpers();
     });
     watcher.on( 'change', function( file_path ){
       if( view_regex.test( file_path ) ) solidus_server.updateView( file_path );
       else if( preprocessor_regex.test( file_path ) ) solidus_server.updatePreprocessor( file_path );
       else if( redirects_regex.test( file_path ) ) solidus_server.setupRedirects();
       else if( auth_regex.test( file_path ) ) solidus_server.setupAuth();
+      else if( helpers_regex.test( file_path ) ) solidus_server.setupSiteHelpers();
     });
 
   };
@@ -350,6 +371,7 @@ var SolidusServer = function( options ){
   this.setupAuth();
   this.setupRedirects();
   this.setupPreprocessors();
+  this.setupSiteHelpers();
 
   if (options.log_server_port) {
     this.startLogServer();

--- a/test/fixtures/site 1/helpers.js
+++ b/test/fixtures/site 1/helpers.js
@@ -1,0 +1,5 @@
+module.exports = {
+  frenchify: function(string) {
+    return 'Le ' + string + ' sacrebleu !';
+  }
+};

--- a/test/fixtures/site 1/preprocessors/helpers.js
+++ b/test/fixtures/site 1/preprocessors/helpers.js
@@ -1,0 +1,4 @@
+module.exports = function(context) {
+  context.test_string = 'Solidus';
+  return context;
+};

--- a/test/fixtures/site 1/views/helpers.hbs
+++ b/test/fixtures/site 1/views/helpers.hbs
@@ -1,5 +1,12 @@
 {{!
 {
-  "layout": false
+  "layout": false,
+  "preprocessor": "helpers.js"
 }
-}}{{uppercase "Handlebars helpers loaded"}}
+}}
+
+{{! Handlebars-helper }}
+{{uppercase test_string}}
+
+{{! Site helper }}
+{{frenchify test_string}}

--- a/test/fixtures/site2/views/helpers.hbs
+++ b/test/fixtures/site2/views/helpers.hbs
@@ -1,0 +1,6 @@
+{{!
+{
+  "layout": false
+}
+}}
+{{uppercase "Site helpers loaded"}}


### PR DESCRIPTION
Custom [Handlebars helpers](http://handlebarsjs.com/block_helpers.html) can be defined in `/helpers.js`. This file needs to export an object defining new helpers, or existing helpers to replace.

```
module.exports = {
  // New helper
  frenchify: function(string) {
    return 'Le ' + string + ' sacrebleu !';
  },

  // Replaces handlebars-helper's uppercase helper
  uppercase: function(string) {
    return string + ' is uppercase';
  },
};
```
