### PR TITLE
Set X-Powered-By header.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -6,6 +6,7 @@ const DEFAULT_DEV_ASSETS_MAX_AGE = 0;
 const DEFAULT_PROD_ASSETS_MAX_AGE = 1000 * 60 * 60 * 24 * 365; // 1 year, in ms
 const SENTRY_DSN = process.env.SENTRY_DSN;
 const SENTRY_LEVEL = process.env.SENTRY_LEVEL;
+const VERSION = require('../package.json').version;
 
 // native
 var fs = require('fs');
@@ -97,6 +98,10 @@ var SolidusServer = function( options ){
   router.set( 'view engine', DEFAULT_VIEW_EXTENSION );
   router.set( 'views', paths.views );
   router.use( express.compress() );
+  router.use(function(req, res, next) {
+    res.set({'X-Powered-By': 'Solidus/' + VERSION});
+    return next();
+  });
   router.use( express.static( paths.assets, {
     maxAge: options.assets_max_age
   }));
@@ -312,7 +317,7 @@ var SolidusServer = function( options ){
     if( params.log_level ) this.logger.level = params.log_level;
     server.listen( params.port, function(){
       solidus_server.emit( 'listen', params.port );
-      solidus_server.logger.log( 'Server running on port '+ params.port, 2 );
+      solidus_server.logger.log('Server ' + VERSION + ' running on port ' + params.port, 2);
     });
 
   };

--- a/test/solidus.js
+++ b/test/solidus.js
@@ -427,6 +427,39 @@ describe( 'Solidus', function(){
         });
     });
 
+    it('Sets the X-Powered-By header for HTML requests', function(done) {
+      var s_request = request(solidus_server.router);
+      s_request
+        .get('/')
+        .expect('X-Powered-By', 'Solidus/' + require('../package.json').version)
+        .end(function(err, res) {
+          if (err) throw err;
+          done();
+        });
+    });
+
+    it('Sets the X-Powered-By header for JSON requests', function(done) {
+      var s_request = request(solidus_server.router);
+      s_request
+        .get('/.json')
+        .expect('X-Powered-By', 'Solidus/' + require('../package.json').version)
+        .end(function(err, res) {
+          if (err) throw err;
+          done();
+        });
+    });
+
+    it('Sets the X-Powered-By header for 404s', function(done) {
+      var s_request = request(solidus_server.router);
+      s_request
+        .get('/nonexistent-url')
+        .expect('X-Powered-By', 'Solidus/' + require('../package.json').version)
+        .end(function(err, res) {
+          if (err) throw err;
+          done();
+        });
+    });
+
     describe( 'resource caching', function(){
 
       function test_caching(cache1, cache2, callback) {


### PR DESCRIPTION
Sets the `X-Powered-By` header to `Solidus/{version}`, for example `Solidus/0.1.7`.
