### PR TITLE
Send logs to a web socket with socket.io.

### DIFF
--- a/bin/solidus
+++ b/bin/solidus
@@ -10,6 +10,8 @@ commander
   .option( '-d, --dev', 'run in development mode' )
   .option( '-r, --livereloadport [type]', '(development mode only) port for LiveReload to listen on [35729]', 35729 )
   .option( '-l, --loglevel [loglevel]', 'run at a specific log level [2]', 2 )
+  .option( '--logserverport [type]', 'port for log server to listen on' )
+  .option( '--logserverlevel [logserverlevel]', 'run log server at a specific log level [2]', 2 )
   .description('Start Solidus')
   .action( function( env ){
     var solidus = require('../solidus.js');
@@ -17,7 +19,9 @@ commander
       port: env.port,
       dev: env.dev,
       log_level: env.loglevel,
-      livereload_port: env.livereloadport
+      livereload_port: env.livereloadport,
+      log_server_port: env.logserverport,
+      log_server_level: env.logserverlevel
     });
   });
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -11,13 +11,21 @@ const level_colors = {
 var Logger = function( options ){
 
   options = _.defaults( options, {
-    level: 2
+    level: 2,
+    log_server_level: 2
   });
   this.level = options.level;
+  this.log_server = options.log_server;
+  this.log_server_level = options.log_server_level;
 
-  this.log = function( message, level ){
+  this.log = function(message, level) {
     level = level || 2;
-    if( this.level >= level ) console.log( '[SOLIDUS]'[level_colors[level]].bold +' '+ message );
+    if (level <= this.level) {
+      console.log('[SOLIDUS]'[level_colors[level]].bold + ' ' + message);
+    }
+    if (level <= this.log_server_level && this.log_server) {
+      this.log_server.emit('log', {level: level, message: message});
+    }
   };
 
 };

--- a/lib/page.js
+++ b/lib/page.js
@@ -288,7 +288,7 @@ var Page = function( page_path, options ){
   // generates the page's markup
   this.render = function( req, res, options ){
 
-    if( server.options.log_level >= 2 ) var start_serve = new Date;
+    var start_serve = new Date;
     options = options || {};
     // generate url data to be served in context
     var href = req.protocol +'://'+ req.get('host') + req.url;
@@ -343,14 +343,14 @@ var Page = function( page_path, options ){
       renderPage( context )
     }, DEFAULT_PAGE_TIMEOUT );
 
-    if( server.options.log_level >= 2 ) var start_resources = new Date;
+    var start_resources = new Date;
     this.fetchResources( page.params.resources, context.parameters,
       function(resource, response) {
         context.resources[resource.name] = response;
       },
       function() {
         server.logger.log( page.route +' resources fetched in '+ ( new Date - start_resources ) +'ms', 3 );
-        if( server.options.log_level >= 2 ) var start_preprocess = new Date;
+        var start_preprocess = new Date;
         page.preprocess( context, function( context ){
           server.logger.log( page.route +' preprocessed in '+ ( new Date - start_preprocess ) +'ms', 3 );
           renderPage( context );

--- a/lib/server.js
+++ b/lib/server.js
@@ -314,7 +314,7 @@ var SolidusServer = function( options ){
   this.start = function( params ){
 
     _.extend( this.options, params );
-    if( params.log_level ) this.logger.level = params.log_level;
+    if (params.log_level !== undefined && params.log_level !== null) this.logger.level = params.log_level;
     server.listen( params.port, function(){
       solidus_server.emit( 'listen', params.port );
       solidus_server.logger.log('Server ' + VERSION + ' running on port ' + params.port, 2);
@@ -322,11 +322,24 @@ var SolidusServer = function( options ){
 
   };
 
+  this.startLogServer = function() {
+    this.logger.log_server = require('socket.io').listen(this.options.log_server_port);
+
+    if (this.options.log_server_level !== undefined && this.options.log_server_level !== null) {
+      this.logger.log_server_level = this.options.log_server_level;
+    } else if (this.options.log_level !== undefined && this.options.log_level !== null) {
+      this.logger.log_server_level = this.options.log_level;
+    }
+
+    this.logger.log('Log server running on port ' + this.options.log_server_port, 2);
+  };
+
   // ends the http listener and stops the server
   this.stop = function(){
 
     server.close();
-    if( this.watcher ) this.watcher.close();
+    if (this.watcher) this.watcher.close();
+    if (this.logger.log_server) this.logger.log_server.engine.close();
 
   };
 
@@ -337,6 +350,10 @@ var SolidusServer = function( options ){
   this.setupAuth();
   this.setupRedirects();
   this.setupPreprocessors();
+
+  if (options.log_server_port) {
+    this.startLogServer();
+  }
 
   if( options.dev ){
     this.watch();

--- a/package.json
+++ b/package.json
@@ -35,13 +35,15 @@
     "handlebars": "~1.0.12",
     "handlebars-helper": "~0.0.9",
     "worker-farm": "~0.3.1",
-    "raven": "^0.6.2"
+    "raven": "^0.6.2",
+    "socket.io": "~1.0.6"
   },
   "devDependencies": {
     "mocha": "~1.9.0",
     "supertest": "~0.6.0",
     "nock": "~0.27.3",
-    "timekeeper": "0.0.4"
+    "timekeeper": "0.0.4",
+    "socket.io-client": "~1.0.6"
   },
   "bin": {
     "solidus": "./bin/solidus"


### PR DESCRIPTION
A log server can be started by specifying the `log_server_port` option. A `log_server_level` can also be set, else `log_level` will be used, else `2`. The web socket library used is [socket.io](http://socket.io), the event name is `log` and the message is an object with two properties: `level` and `message`. Example usage:

```
<script src="socket.io.js"></script>
<script>
  var socket = io('http://localhost:8089');
  socket.on('connect', function(){
    console.log('connected')
    socket.on('log', function(data){console.log(data)});
    socket.on('disconnect', function(){console.log('disconnected')});
  });
</script>
```

Once this change is merged, I'll need to modify [vagrant-solidus](https://github.com/solidusjs/vagrant-solidus) and [solidus-site-template](https://github.com/solidusjs/solidus-site-template) to automatically open a port for the log server in dev.
