### PR TITLE
Client-side view rendering

### DIFF
--- a/lib/cached_resource.js
+++ b/lib/cached_resource.js
@@ -1,85 +1,75 @@
-const DEFAULT_FRESHNESS_LIFETIME = 60 * 1000; // 60 seconds
-const LOCK_TIMEOUT = 30 * 1000; // 30 seconds
+const MAX_RESOURCES_CACHE = 50;
+const MAX_RESOURCE_AGE = 1000 * 60 * 60 * 24; // 24 hours
+const DEFAULT_RESOURCE_FRESHNESS = 60 * 1000; // 60 seconds
+const SUCCESSFUL_RESPONSE_CODES = [200];
 
-var CachedResource = function(spec) {
-  this.data = spec.data;
-  this.expires_at = expiresAt(spec.response, spec.request_time, spec.response_time);
-  this.locked_at = 0;
+var _ = require('underscore');
+var lru = require('lru-cache');
+var Resource = require('solidus-client/lib/resource');
+var ResourceResponse = require('./resource_response.js');
 
-  this.expired = function() {
-    return new Date().getTime() >= this.expires_at;
-  };
+var cache = lru({
+  max: MAX_RESOURCES_CACHE,
+  length: function() {return 1},
+  maxAge: MAX_RESOURCE_AGE
+});
 
-  this.lock = function() {
-    if (new Date().getTime() >= this.locked_at + LOCK_TIMEOUT) {
-      this.locked_at = new Date().getTime();
-      return true;
-    } else {
-      return false;
+var CachedResource = function(options, auth, params, logger) {
+  this.resource = new Resource(options, auth, params);
+  this.logger = logger;
+};
+
+CachedResource.prototype.get = function(callback) {
+  if (!this.resource.url) return callback(null, {});
+
+  // TODO: include the auth in the cache key
+  var resource_response = cache.get(this.resource.url);
+  if (resource_response) {
+    this.logger.log('Resource recovered from cache: ' + this.resource.url, 3);
+    refreshCache.call(this, resource_response);
+    callback(null, resource_response);
+  } else {
+    getAndCache.call(this, callback);
+  }
+};
+
+// PRIVATE
+
+var refreshCache = function(resource_response) {
+  if (!resource_response.expired() || !resource_response.lock()) return;
+
+  // The cache is expired, refresh it in the next event loop cycle
+  var self = this;
+  process.nextTick(function() {
+    self.logger.log('Refreshing expired cached resource: ' + self.resource.url, 3);
+    getAndCache.call(self, function() {
+      resource_response.unlock();
+    });
+  });
+};
+
+var getAndCache = function(callback) {
+  var self = this;
+
+  self.resource.get(function(err, res) {
+    if (err) return callback(err, null);
+
+    self.logger.log('Requested resource: [' + res.response.statusCode + '] ' + self.resource.url, 3);
+    var resource_response = new ResourceResponse(res);
+
+    if (SUCCESSFUL_RESPONSE_CODES.indexOf(res.response.statusCode) > -1) {
+      if (!resource_response.has_expiration) {
+        // The response has no cache headers, cache for a default duration
+        resource_response.expires_at = new Date().getTime() + DEFAULT_RESOURCE_FRESHNESS;
+      }
+      // TODO: include the auth in the cache key
+      cache.set(self.resource.url, resource_response);
     }
-  };
 
-  this.unlock = function() {
-    this.locked_at = 0;
-  };
+    callback(null, resource_response);
+  });
 };
 
-// https://developer.mozilla.org/en/docs/HTTP_Caching_FAQ
-var expiresAt = function(response, request_time, response_time) {
-  return new Date().getTime() + freshnessLifetime(response, request_time) - currentAge(response, request_time, response_time);
-};
-
-// http://tools.ietf.org/html/rfc2616#section-13.2.4
-var freshnessLifetime = function(response, request_time) {
-  var cache_control = parseCacheControl(response.headers['cache-control'] || '');
-
-  if (cache_control.hasOwnProperty('s-maxage') && cache_control['s-maxage'] !== true) {
-    return cache_control['s-maxage'] * 1000;
-  }
-
-  if (cache_control.hasOwnProperty('max-age') && cache_control['max-age'] !== true) {
-    return cache_control['max-age'] * 1000;
-  }
-
-  if (response.headers['expires']) {
-    var expires = parseDate(response.headers['expires']);
-    var date = parseDate(response.headers['date']) || request_time;
-    return expires - date;
-  }
-
-  return DEFAULT_FRESHNESS_LIFETIME;
-};
-
-// http://tools.ietf.org/html/rfc2616#section-13.2.3
-// http://greenbytes.de/tech/webdav/draft-ietf-httpbis-p6-cache-22.html#age.calculations
-var currentAge = function(response, request_time, response_time) {
-  var apparent_age = Math.max(0, response_time - (parseDate(response.headers['date']) || request_time));
-  var response_delay = response_time - request_time;
-  var corrected_age_value = response.headers['age'] ? response.headers['age'] * 1000 + response_delay : 0;
-  var corrected_initial_age = Math.max(apparent_age, corrected_age_value);
-  var resident_time = new Date().getTime() - response_time;
-  var current_age = corrected_initial_age + resident_time;
-
-  return current_age;
-};
-
-var parseCacheControl = function(header) {
-  var directives = header.split(',');
-  var obj = {};
-
-  for(var i = 0, len = directives.length; i < len; i++) {
-    var parts = directives[i].split('=');
-    var key = parts.shift().trim();
-    var val = parseInt(parts.shift(), 10);
-
-    obj[key] = isNaN(val) ? true : val;
-  }
-
-  return obj;
-};
-
-var parseDate = function(header) {
-  return header ? Date.parse(header) : null;
-};
+CachedResource.cache = cache;
 
 module.exports = CachedResource;

--- a/lib/page.js
+++ b/lib/page.js
@@ -1,10 +1,7 @@
 const DEFAULT_ENCODING = 'UTF8';
 const DEFAULT_PAGE_TIMEOUT = 5000;
-const MAX_RESOURCES_CACHE = 50;
-const MAX_RESOURCE_AGE = 1000 * 60 * 60 * 24; // 24 hours
 const MODIFIED_ROUND_TIME = 1000 * 60 * 5; // 5 minutes
 const EXPIRY_TIME = 1000 * 60 * 5; // 5 minutes
-const SUCCESSFUL_RESPONSE_CODES = [ 200 ]; // 200 OK
 
 var url = require('url');
 var fs = require('fs');
@@ -14,33 +11,15 @@ var EventEmitter = require('events').EventEmitter;
 
 var _ = require('underscore');
 var async = require('async');
-var hyperquest = require('hyperquest');
-var lru = require('lru-cache');
-var zlib = require('zlib');
-var cache = lru({
-  max: MAX_RESOURCES_CACHE,
-  length: function( n ){ return 1 },
-  maxAge: MAX_RESOURCE_AGE
-});
 
 var CachedResource = require('./cached_resource.js');
 var routing = require('./routing.js');
-
-// escape backslashes in path for use in regex
-var escapePathForRegex = function( file_path ){
-  return file_path.replace( /(\\)/g, '\\\\' );
-};
 
 // rounds datetime to nearest 5 minutes (in the past)
 var getRoundedTime = function( datetime, round_by ){
   var remainder = datetime % round_by;
   var rounded_time = new Date( datetime - remainder );
   return rounded_time;
-};
-
-// checks if a string is a resource url
-var isURL = function( string ){
-  return /https?:\/\//.test( string );
 };
 
 var Page = function( page_path, options ){
@@ -95,8 +74,6 @@ var Page = function( page_path, options ){
   // reads the json configuration inside the view
   this.parseConfig = function( callback ){
 
-    var auth_options = server.auth;
-
     fs.readFile( this.path, DEFAULT_ENCODING, function( err, data ){
 
       var params = {};
@@ -107,62 +84,104 @@ var Page = function( page_path, options ){
       catch( err ){
         server.logger.log( 'Error preprocessing "'+ page.path +'" '+ err, 0 );
       }
-      finally {
-        // insert global resource data by name
-        if( params.resources ){
-          for( var name in params.resources ){
-            // reassign string contents to url property
-            if( _.isString( params.resources[name] ) ){
-              params.resources[name] = {
-                url: params.resources[name]
-              }
-            }
-            // mixin global resource options
-            if( auth_options ){
-              _.each( auth_options, function( options, match ){
-                var matcher = new RegExp( match, 'ig' );
-                if( matcher.test( params.resources[name].url ) ){
-                  params.resources[name] = _.extend( params.resources[name], options );
-                }
-              });
-            }
-          }
-        }
-        page.params = params;
-        _( page ).extend({
-          title: params.title,
-          description: params.description,
-          name: params.name,
-          layout: params.layout
-        });
-        if( callback ) callback( params );
-      }
+      params.resources = params.resources || {};
+
+      page.partials = page.findPartials(data);
+
+      page.params = params;
+      _( page ).extend({
+        title: params.title,
+        description: params.description,
+        name: params.name,
+        layout: params.layout
+      });
+      if( callback ) callback( params );
 
     });
 
   };
 
+  // finds the names of the partials used by the template
+  this.findPartials = function(template) {
+    var template_without_comments = template.replace(/{{!--[\s\S]*?--}}/g, '').replace(/{{![\s\S]*?}}/g, '');
+    var partials = [];
+    var partial_regex = /{{>\s*([^\s}]+)[\s\S]*?}}/g;
+    var match;
+    while (match = partial_regex.exec(template_without_comments)) {
+      // Fix quoted strings
+      var name = match[1].replace(/(^['"])|(["']$)/g, '').replace(/\\(['"])/, '$1');
+      partials.push(name);
+    }
+    return _.uniq(partials);
+  }
+
+  this.allPartials = function() {
+    var partials = {};
+    _.each(page.partials, function(name) {
+      var file_path  = server.pathFromPartialName(name);
+      partials[name] = file_path;
+
+      var partial = server.views[file_path];
+      if (partial) {
+        partials = _.extend(partials, partial.allPartials());
+      }
+    });
+    return partials;
+  };
+
+  this.toObjectString = function(parent_file_path) {
+    var root = path.dirname(parent_file_path);
+    var preprocessor = server.preprocessors[page.params.preprocessor];
+    var partials = page.allPartials();
+    var properties = [];
+    var template_options = [];
+
+    if (!_.isEmpty(page.params.resources)) {
+      properties.push('resources:' + JSON.stringify(page.params.resources));
+    }
+
+    if (preprocessor) {
+      properties.push('preprocessor:require(' + JSON.stringify(path.relative(root, preprocessor.path)) + ')');
+    }
+
+    properties.push('template:require(' + JSON.stringify(path.relative(root, page.path)) + ')');
+
+    if (!_.isEmpty(server.site_helpers)) {
+      template_options.push('helpers:require(' + JSON.stringify(path.relative(root, server.paths.helpers)) + ')');
+    }
+
+    if (!_.isEmpty(partials)) {
+      var requires = _.map(partials, function(file_path, name) {
+        return JSON.stringify(name) + ':require(' + JSON.stringify(path.relative(root, file_path)) + ')';
+      })
+      template_options.push('partials:{' + requires.join(',') + '}');
+    }
+
+    if (!_.isEmpty(template_options)) {
+      properties.push('template_options:{' + template_options.join(',') + '}');
+    }
+
+    return '{' + properties.join(',') + '}';
+  };
+
   // fetches remote resources
-  this.fetchResources = function( resources, params, iterator, callback ){
+  this.fetchResources = function( params, iterator, callback ){
 
     var page = this;
 
-    if( resources ){
+    if( page.params.resources ){
       // convert resources object into array
-      var resources_array = _( resources ).map( function( data, name ){
-        var resource = {
-          name: name,
-          data: data
-        };
+      var resources_array = _( page.params.resources ).map( function( options, name ){
+        var resource = new CachedResource(options, server.auth, params, server.logger);
+        resource.name = name;
         return resource;
       });
-      // loop through array to create new resources object
       async.each( resources_array, function( resource, cb ){
-        page.fetchResource( resource.data, params, function( err, response ){
+        resource.get(function(err, resource_response) {
           if( err ){
             server.logger.log( 'Error retrieving resource "'+ resource.name +'": '+ err, 3 );
           } else {
-            iterator(resource, response);
+            iterator(resource, resource_response);
           }
           cb();
         });
@@ -172,96 +191,6 @@ var Page = function( page_path, options ){
       callback();
     }
 
-  };
-
-  // fetches a single resource and returns its contents
-  this.fetchResource = function( resource_data, params, callback ){
-    var page = this;
-
-    var resource_url = resource_data.url;
-    if( !isURL( resource_url ) ) return callback( null, {} );
-    // replace variable strings like {this} in the resource url with url or query parameters
-    resource_url = routing.expandVariables(resource_url, params);
-    // loop through query params looking for dynamic bits
-    var query = [];
-    for( var key in resource_data.query ){
-      if( typeof resource_data.query[key] === 'string' ){
-        resource_data.query[key] = routing.expandVariables(resource_data.query[key], params);
-      }
-      query.push(key.toString() + '=' + resource_data.query[key].toString());
-    }
-    if (query.length) {
-      resource_url += resource_url.indexOf('?') == -1 ? '?' : '&';
-      resource_url += query.join('&');
-    }
-
-    // attempt to get resource from cache
-    var cached_resource = cache.get( resource_url );
-    if( cached_resource ){
-      page.fetchAndRefreshCachedResource(cached_resource, resource_url, resource_data, callback);
-    } else {
-      page.fetchAndCacheResource(resource_url, resource_data, callback);
-    }
-  };
-
-  this.fetchAndRefreshCachedResource = function(cached_resource, resource_url, resource_data, callback){
-    var page = this;
-
-    if (cached_resource.expired() && cached_resource.lock()) {
-      // The cached resource is expired, refresh it in the next event loop cycle
-      process.nextTick(function() {
-        server.logger.log( 'Refreshing expired cached resource: '+ resource_url, 3 );
-        page.fetchAndCacheResource(resource_url, resource_data, function() {
-          cached_resource.unlock();
-        });
-      });
-    }
-
-    server.logger.log( 'Resource recovered from cache: '+ resource_url, 3 );
-    callback( null, cached_resource.data );
-  };
-
-  // fetches a single resource and returns its contents
-  this.fetchAndCacheResource = function(resource_url, resource_data, callback){
-    // retrieve compressed resources if possible
-    if ( !resource_data.headers ) resource_data.headers = {};
-    if ( !resource_data.headers['Accept-Encoding'] ) resource_data.headers['Accept-Encoding'] = 'gzip,deflate';
-
-    // fetch resource remotely
-    var request_time = new Date().getTime();
-    hyperquest( resource_url, resource_data, function( err, res ){
-      if( err ) return callback( err, null );
-
-      var data = '';
-      var response_stream = res;
-      var response_time = new Date().getTime();
-
-      // log all resource requests
-      server.logger.log( 'Requested resource: ['+ res.statusCode +'] '+ resource_url, 3 );
-
-      if( res.headers['content-encoding'] == 'gzip' || res.headers['content-encoding'] == 'deflate' ) {
-        response_stream = res.pipe( new zlib.Unzip() );
-      }
-
-      response_stream.on( 'data', function onData( chunk ){
-        data += chunk;
-      });
-      response_stream.on( 'end', function onEnd(){
-        try {
-          data = data.toString( DEFAULT_ENCODING );
-          data = JSON.parse( data );
-        } catch( err ){
-          return callback( err, null );
-        }
-
-        // cache resource if it came back successful
-        if( SUCCESSFUL_RESPONSE_CODES.indexOf( res.statusCode ) > -1 ){
-          cache.set( resource_url, new CachedResource( {response: res, data: data, request_time: request_time, response_time: response_time} ) );
-        }
-
-        return callback( null, data );
-      });
-    });
   };
 
   // preprocesses the page's context
@@ -340,9 +269,9 @@ var Page = function( page_path, options ){
     }, DEFAULT_PAGE_TIMEOUT );
 
     var start_resources = new Date;
-    this.fetchResources( page.params.resources, context.parameters,
-      function(resource, response) {
-        context.resources[resource.name] = response;
+    this.fetchResources( context.parameters,
+      function(resource, resource_response) {
+        context.resources[resource.name] = resource_response.data;
       },
       function() {
         server.logger.log( page.route +' resources fetched in '+ ( new Date - start_resources ) +'ms', 3 );
@@ -393,6 +322,5 @@ var Page = function( page_path, options ){
 util.inherits( Page, EventEmitter );
 
 Page.layouts = {};
-Page.cache = cache;
 
 module.exports = Page;

--- a/lib/resource_response.js
+++ b/lib/resource_response.js
@@ -1,0 +1,98 @@
+const LOCK_TIMEOUT = 30 * 1000; // 30 seconds
+
+var ResourceResponse = function(spec) {
+  this.data = spec.data;
+  this.expires_at = expiresAt(spec.response, spec.request_time, spec.response_time);
+  this.locked_at = 0;
+
+  if (this.expires_at) {
+    this.has_expiration = true;
+  } else {
+    this.has_expiration = false;
+    this.expires_at = new Date().getTime();
+  }
+
+  this.maxAge = function() {
+    return Math.max(0, Math.ceil((this.expires_at - new Date().getTime()) / 1000));
+  };
+
+  this.expired = function() {
+    return new Date().getTime() >= this.expires_at;
+  };
+
+  this.lock = function() {
+    if (new Date().getTime() >= this.locked_at + LOCK_TIMEOUT) {
+      this.locked_at = new Date().getTime();
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  this.unlock = function() {
+    this.locked_at = 0;
+  };
+};
+
+// https://developer.mozilla.org/en/docs/HTTP_Caching_FAQ
+var expiresAt = function(response, request_time, response_time) {
+  var freshness_lifetime = freshnessLifetime(response, request_time);
+  if (freshness_lifetime === null) return null;
+
+  return new Date().getTime() + freshness_lifetime - currentAge(response, request_time, response_time);
+};
+
+// http://tools.ietf.org/html/rfc2616#section-13.2.4
+var freshnessLifetime = function(response, request_time) {
+  var cache_control = parseCacheControl(response.headers['cache-control'] || '');
+
+  if (cache_control.hasOwnProperty('s-maxage') && cache_control['s-maxage'] !== true) {
+    return cache_control['s-maxage'] * 1000;
+  }
+
+  if (cache_control.hasOwnProperty('max-age') && cache_control['max-age'] !== true) {
+    return cache_control['max-age'] * 1000;
+  }
+
+  if (response.headers['expires']) {
+    var expires = parseDate(response.headers['expires']);
+    var date = parseDate(response.headers['date']) || request_time;
+    return expires - date;
+  }
+
+  return null;
+};
+
+// http://tools.ietf.org/html/rfc2616#section-13.2.3
+// http://greenbytes.de/tech/webdav/draft-ietf-httpbis-p6-cache-22.html#age.calculations
+var currentAge = function(response, request_time, response_time) {
+  var apparent_age = Math.max(0, response_time - (parseDate(response.headers['date']) || request_time));
+  var response_delay = response_time - request_time;
+  var corrected_age_value = response.headers['age'] ? response.headers['age'] * 1000 + response_delay : 0;
+  var corrected_initial_age = Math.max(apparent_age, corrected_age_value);
+  var resident_time = new Date().getTime() - response_time;
+  var current_age = corrected_initial_age + resident_time;
+
+  return current_age;
+};
+
+var parseCacheControl = function(header) {
+  var directives = header.split(',');
+  var obj = {};
+
+  for (var i = 0, len = directives.length; i < len; i++) {
+    var parts = directives[i].split('=');
+    var key = parts.shift().trim();
+    var val = parseInt(parts.shift(), 10);
+
+    obj[key] = isNaN(val) ? true : val;
+  }
+
+  return obj;
+};
+
+var parseDate = function(header) {
+  return header ? Date.parse(header) : null;
+};
+
+module.exports = ResourceResponse;

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,6 +9,7 @@ const DEFAULT_PROD_LOG_LEVEL = 2;
 const SENTRY_DSN = process.env.SENTRY_DSN;
 const SENTRY_LEVEL = process.env.SENTRY_LEVEL;
 const VERSION = require('../package.json').version;
+const DEFAULT_API_ROUTE = '/api/';
 
 // native
 var fs = require('fs');
@@ -39,6 +40,7 @@ var Page = require('./page.js');
 var Preprocessor = require('./preprocessor.js');
 var Redirect = require('./redirect.js');
 var Logger = require('./logger.js');
+var CachedResource = require('./cached_resource.js');
 
 // make the path into a Windows compatible path
 var deGlobifyPath = function( file_path ){
@@ -64,7 +66,9 @@ var SolidusServer = function( options ){
     log_level: options.dev ? DEFAULT_DEV_LOG_LEVEL : DEFAULT_PROD_LOG_LEVEL,
     site_path: process.cwd(),
     assets_max_age: options.dev ? DEFAULT_DEV_ASSETS_MAX_AGE : DEFAULT_PROD_ASSETS_MAX_AGE,
-    livereload_port: DEFAULT_LIVERELOAD_PORT
+    livereload_port: DEFAULT_LIVERELOAD_PORT,
+    api_route: DEFAULT_API_ROUTE,
+    start_server: true
   };
   this.options = options = _( options ).defaults( defaults );
 
@@ -168,6 +172,12 @@ var SolidusServer = function( options ){
   });
 
   var layout_regex = new RegExp( '\/layout\.hbs$', 'i' );
+
+  this.pathFromPartialName = function(partial_name) {
+    var partial_path = path.join(this.paths.views, partial_name + '.' + DEFAULT_VIEW_EXTENSION);
+    if (!this.views[partial_path]) partial_path = path.join(this.paths.extra_partials, partial_name + '.' + DEFAULT_VIEW_EXTENSION);
+    return partial_path;
+  };
 
   // adds a new page
   // adds a new layout if the view is a layout
@@ -314,6 +324,27 @@ var SolidusServer = function( options ){
     this.site_helpers = site_helpers;
   };
 
+  this.setupApi = function() {
+    var self = this;
+    this.router.get(this.options.api_route + 'resource.json', function(req, res) {
+      if (!req.query.url) return res.json(400, {error: "Missing 'url' parameter"});
+      var cached_resource = new CachedResource(req.query.url, solidus_server.auth, {}, solidus_server.logger);
+      if (!cached_resource.resource.url) return res.json(400, {error: "Invalid 'url' parameter"});
+
+      cached_resource.get(function(err, resource_response) {
+        if (err) return res.json(400, {error: err});
+
+        if (!self.options.dev) {
+          res.set({
+            'Cache-Control': 'public, max-age=' + resource_response.maxAge(),
+            'Expires': new Date(resource_response.expires_at).toUTCString()
+          });
+        }
+        res.json(resource_response.data);
+      });
+    });
+  };
+
   // watches preprocessors dir and adds/removes when necessary
   this.watch = function(){
 
@@ -404,18 +435,27 @@ var SolidusServer = function( options ){
   this.setupPreprocessors();
   this.setupSiteHelpers();
 
-  if (options.log_server_port) {
-    this.startLogServer();
+  if (options.start_server) {
+    this.setupApi();
+
+    if (options.log_server_port) {
+      this.startLogServer();
+    }
+
+    if (options.dev) {
+      this.watch();
+    }
+
+    this.start({
+      port: options.port
+    });
   }
 
-  if( options.dev ){
-    this.watch();
-  }
+};
 
-  this.start({
-    port: options.port
-  });
-
+SolidusServer.extensions = {
+  template: DEFAULT_VIEW_EXTENSION,
+  preprocessor: 'js'
 };
 
 // properly inherit from EventEmitter part 2

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "worker-farm": "~1.1.0",
     "raven": "^0.6.2",
     "socket.io": "~1.0.6",
-    "continuation-local-storage": "~3.1.1"
+    "continuation-local-storage": "~3.1.1",
+    "solidus-client": "git+https://github.com/solidusjs/solidus-client.git#solidus-client",
+    "browserify-transform-tools": "~1.2.1"
   },
   "devDependencies": {
     "mocha": "~1.9.0",

--- a/solidify.js
+++ b/solidify.js
@@ -1,0 +1,35 @@
+var path = require('path');
+var SolidusServer = require('./lib/server');
+var transformTools = require('browserify-transform-tools');
+
+var solidus_server;
+
+// Browserify transform that inlines requires to Solidus JS views.
+// For example, this code:
+//   var view = require('solidus/views/some/view'); // The path can end with .js too
+// Becomes something like:
+//   var view = {template:require("../../views/some/view.hbs"),template_options:{helpers:require("../../helpers.js")}};
+module.exports = transformTools.makeRequireTransform(
+  'solidus/solidify',
+  {excludeExtensions: ['.' + SolidusServer.extensions.template]},
+  function(args, opts, callback) {
+    var view_name = args[0].match(/^solidus\/views\/(.*?)(\.js)?$/);
+    if (!view_name) return callback();
+    view_name = view_name[1];
+
+    var waitForSolidus = function() {
+      if (!solidus_server) {
+        solidus_server = new SolidusServer({start_server: false});
+        solidus_server.on('ready', function() {solidus_server.ready = true});
+      }
+
+      if (solidus_server.ready) {
+        var view = solidus_server.views[solidus_server.pathFromPartialName(view_name)];
+        callback(null, view ? view.toObjectString(opts.file) : null);
+      } else {
+        setImmediate(waitForSolidus);
+      }
+    };
+    waitForSolidus();
+  }
+);

--- a/test/fixtures/site 1/views/index.hbs
+++ b/test/fixtures/site 1/views/index.hbs
@@ -11,8 +11,7 @@
     "resource-options-query": {
       "url": "https://solid.us/resource/options/query",
       "query": {
-        "test": true,
-        "not,encoded": "not;encoded"
+        "test": true
       }
     },
     "resource-options-headers": {
@@ -28,8 +27,10 @@
       }
     },
     "resource-options-double-dynamic-query": {
-      "url": "https://solid.us/resource/options/double/dynamic/query?test2={resource_test2}",
+      "url": "https://solid.us/resource/options/double/dynamic/query?a=,&b=%2C&test2={resource_test2}",
       "query": {
+        "c": ",",
+        "d": "%2C",
         "test": "{resource_test}"
       }
     },

--- a/test/fixtures/site 1/views/multiple_partials.hbs
+++ b/test/fixtures/site 1/views/multiple_partials.hbs
@@ -1,0 +1,37 @@
+{{!
+{
+  "title": "test"
+}
+}}
+
+{{>partial1}}
+{{>partial1}}
+{{>partial1 some-context}}
+
+{{>  partial2    }}
+{{>  partial2  some-context    }}
+
+{{>
+partial3
+}}
+{{>
+partial3
+some-context
+}}
+
+{{>partial/4}}
+
+{{!{{>partial5}}}}
+{{!
+  {{>partial6}}
+}}
+{{!--{{>partial7}}--}}
+{{!--
+  {{>partial8}}
+--}}
+
+{{>'partial9'}}
+{{>'partial\'10'}}
+
+{{>"partial11"}}
+{{>"partial\"12"}}

--- a/test/fixtures/site 1/views/with_all_features.hbs
+++ b/test/fixtures/site 1/views/with_all_features.hbs
@@ -1,0 +1,13 @@
+{{!
+{
+  "resources": {
+    "cache1": "https://solid.us/cache/1",
+    "cache2": "https://solid.us/cache/2"
+  },
+  "preprocessor": "index.js"
+}
+}}
+
+{{>partial}}
+{{>partial_holder}}
+{{>partial_holder2}}

--- a/test/solidify.js
+++ b/test/solidify.js
@@ -1,0 +1,67 @@
+var assert = require('assert');
+var path = require('path');
+var solidify = require('../solidify.js');
+var transformTools = require('browserify-transform-tools');
+
+var original_path = __dirname;
+var site1_path = path.join(original_path, 'fixtures', 'site 1');
+var dummyJsFile = path.join(site1_path, 'assets', 'scripts', 'index.js');
+
+describe('Solidify transform', function() {
+  before(function(done) {
+    process.chdir(site1_path);
+    done();
+  });
+
+  after(function() {
+    process.chdir(original_path);
+  });
+
+  it('replaces required views with their JS version', function(done) {
+    var content = 'var a = require("solidus/views/dynamic/{segment}");';
+    var expected = 'var a = {template:require("../../views/dynamic/{segment}.hbs"),template_options:{helpers:require("../../helpers.js")}};'
+    transformTools.runTransform(solidify, dummyJsFile, {content: content}, function(err, transformed) {
+      assert.ifError(err);
+      assert.equal(transformed, expected);
+      done();
+    });
+  });
+
+  it('with multiple requires', function(done) {
+    var content = 'var a = require("solidus/views/dynamic/{segment}");var b = require("solidus/views/dynamic/{segment}.js");var c = require("solidus/views/partial");';
+    var expected = 'var a = {template:require("../../views/dynamic/{segment}.hbs"),template_options:{helpers:require("../../helpers.js")}};var b = {template:require("../../views/dynamic/{segment}.hbs"),template_options:{helpers:require("../../helpers.js")}};var c = {template:require("../../views/partial.hbs"),template_options:{helpers:require("../../helpers.js")}};'
+    transformTools.runTransform(solidify, dummyJsFile, {content: content}, function(err, transformed) {
+      assert.ifError(err);
+      assert.equal(transformed, expected);
+      done();
+    });
+  });
+
+  it('with view using partial from extra package', function(done) {
+    var content = 'var a = require("solidus/views/partial_holder3");';
+    var expected = 'var a = {template:require("../../views/partial_holder3.hbs"),template_options:{helpers:require("../../helpers.js"),partials:{"partial":require("../../views/partial.hbs"),"extra/partial":require("../../node_modules/extra/partial.hbs"),"extra/conflict":require("../../views/extra/conflict.hbs")}}};'
+    transformTools.runTransform(solidify, dummyJsFile, {content: content}, function(err, transformed) {
+      assert.ifError(err);
+      assert.equal(transformed, expected);
+      done();
+    });
+  });
+
+  it('with bad extension', function(done) {
+    var content = 'var a = require("solidus/views/partial.hbs");var b = require("solidus/views/partial.html");';
+    transformTools.runTransform(solidify, dummyJsFile, {content: content}, function(err, transformed) {
+      assert.ifError(err);
+      assert.equal(transformed, content);
+      done();
+    });
+  });
+
+  it('with bad name', function(done) {
+    var content = 'var a = require("solidus/views/wrong");';
+    transformTools.runTransform(solidify, dummyJsFile, {content: content}, function(err, transformed) {
+      assert.ifError(err);
+      assert.equal(transformed, content);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
In order to render views on the client, the context preparation done in Solidus needs to be replicated in the browser. This is done by [solidus-client](https://github.com/solidusjs/solidus-client).

This PR adds the ability to export the Solidus views to the browser, so solidus-client can use them. This is achieved with a custom [Browserify](http://browserify.org) transform, named solidify.

Simple example:

`assets/scripts/index.js`
```javascript
var SolidusClient = require('solidus-client');
var view = require('solidus/views/my/view'); // Can end with .js, but not with .hbs

var solidus_client = new SolidusClient();
solidus_client
  .render(view)
  .end(function(html) {
    console.log(html);
  });
```

`gruntfile.js`
```javascript
//...
    browserify: {
      scripts: {
        options: {
          transform: ['solidus/solidify', 'hbsfy']
        },
        files: {
          'assets/compiled/scripts.js': ['assets/scripts/index.js']
        }
      }
    },

//...
  grunt.registerTask( 'compilejs', ['browserify'] );
```
