### PR TITLE
Include partials from `node_modules`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ logs
 results
 
 npm-debug.log
-node_modules/
+/node_modules/

--- a/lib/server.js
+++ b/lib/server.js
@@ -28,7 +28,7 @@ var expose = require('express-expose');
 var Handlebars = require('handlebars');
 var handlebars_helper = require('handlebars-helper');
 handlebars_helper.help( Handlebars );
-var express_handlebars = require('express3-handlebars');
+var express_handlebars = require('express-handlebars');
 var chokidar = require('chokidar');
 var glob = require('glob');
 var raven = require('raven');
@@ -72,6 +72,7 @@ var SolidusServer = function( options ){
   var paths = this.paths = {
     site: options.site_path,
     views: path.join( options.site_path, 'views' ),
+    extra_partials: path.join( options.site_path, 'node_modules' ),
     auth: path.join( options.site_path, 'auth.json' ),
     redirects: path.join( options.site_path, 'redirects.js' ),
     preprocessors: path.join( options.site_path, 'preprocessors' ),
@@ -96,12 +97,17 @@ var SolidusServer = function( options ){
   var server = this.server = http.createServer( router );
   var hbs_config = {
     extname: '.hbs',
-    partialsDir: paths.views,
+    partialsDir: [paths.views],
     layoutsDir: paths.views,
     handlebars: Handlebars
   };
   if( fs.existsSync( path.join( paths.views, 'layout.hbs' ) ) ) hbs_config.defaultLayout = 'layout';
   var handlebars = this.handlebars = express_handlebars.create( hbs_config );
+
+  // Preload the extra partials, no need to reload them at every request in dev
+  // Move them first in partialsDir, so local views win in name conflicts
+  handlebars.partialsDir.unshift({templates: handlebars.getTemplates(paths.extra_partials)});
+
   router.engine( DEFAULT_VIEW_EXTENSION, handlebars.engine );
   router.set( 'view engine', DEFAULT_VIEW_EXTENSION );
   router.set( 'views', paths.views );

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "express": "3.1.x",
-    "express3-handlebars": "0.4.x",
+    "express-handlebars": "1.1.0",
     "express-expose": "git+http://github.com/SparkartGroupInc/express-expose.git#escape-script-ending-tag",
     "underscore": "1.4.x",
     "async": "0.2.x",

--- a/test/fixtures/site 1/node_modules/extra/conflict.hbs
+++ b/test/fixtures/site 1/node_modules/extra/conflict.hbs
@@ -1,0 +1,1 @@
+Partial with same path as site partial (site 1/views/extra/conflict).

--- a/test/fixtures/site 1/node_modules/extra/partial.hbs
+++ b/test/fixtures/site 1/node_modules/extra/partial.hbs
@@ -1,0 +1,1 @@
+Partial from external module.

--- a/test/fixtures/site 1/views/extra/conflict.hbs
+++ b/test/fixtures/site 1/views/extra/conflict.hbs
@@ -1,0 +1,1 @@
+Partial with same path as external partial (site 1/node_modules/extra/conflict).

--- a/test/fixtures/site 1/views/partial_holder3.hbs
+++ b/test/fixtures/site 1/views/partial_holder3.hbs
@@ -1,0 +1,7 @@
+{{!
+{
+  "layout": false
+}
+}}{{>partial}}
+{{>extra/partial}}
+{{>extra/conflict}}

--- a/test/solidus.js
+++ b/test/solidus.js
@@ -421,6 +421,17 @@ describe( 'Solidus', function(){
       });
     });
 
+    it( 'Makes partials available from node_modules', function( done ){
+      request(solidus_server.router)
+        .get('/partial_holder3/')
+        .expect(200)
+        .end(function(err, res) {
+          assert.ifError(err);
+          assert.equal(res.text, 'partial.hbs\nPartial from external module.\nPartial with same path as external partial (site 1/node_modules/extra/conflict).');
+          done();
+        });
+    });
+
     it( 'Sends appropriate cache headers with pages', function( done ){
       var s_request = request( solidus_server.router );
       s_request


### PR DESCRIPTION
This PR adds the site's `node_modules` folder as a [partials dir in express-handlebars](https://github.com/ericf/express-handlebars#partialsdirviewspartials). All modules installed by the site can then be used for partials:

```
{{> some-package/views/news}}
```

Note that those views will always be cached, even in dev.

Fixes #104.
Fixes #123.
