### PR TITLE
Do not use git urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "express": "3.1.x",
     "express-handlebars": "1.2.2",
-    "express-expose": "git+http://github.com/SparkartGroupInc/express-expose.git#escape-script-ending-tag",
+    "express-expose": "SparkartGroupInc/express-expose#escape-script-ending-tag",
     "underscore": "1.4.x",
     "async": "0.2.x",
     "commander": "1.1.x",


### PR DESCRIPTION
To fix "The authenticity of host 'github.com (192.30.252.131)' can't be established." problems when installing.