### PR TITLE
No-cache requests

### DIFF
--- a/lib/cached_resource.js
+++ b/lib/cached_resource.js
@@ -6,6 +6,7 @@ var _ = require('underscore');
 var lru = require('lru-cache');
 var Resource = require('solidus-client/lib/resource');
 var ResourceResponse = require('./resource_response.js');
+var utils = require('./utils.js');
 
 var cache = lru({
   max: MAX_RESOURCES_CACHE,
@@ -14,15 +15,17 @@ var cache = lru({
 });
 
 var CachedResource = function(options, auth, params, logger) {
-  this.resource = new Resource(options, auth, params);
-  this.options  = this.resource.options;
-  this.logger   = logger;
+  this.resource  = new Resource(options, auth, params);
+  this.options   = this.resource.options;
+  this.logger    = logger;
+  this.no_cache  = utils.hasNoCacheHeader(this.options.headers);
+  this.cache_key = cacheKey.call(this);
 };
 
 CachedResource.prototype.get = function(callback) {
   if (!this.resource.url) return callback(null, {});
 
-  var resource_response = cache.get(this.resource.key());
+  var resource_response = !this.no_cache && cache.get(this.cache_key);
   if (resource_response) {
     this.logger.log('Resource recovered from cache: ' + this.resource.url, 3);
     refreshCache.call(this, resource_response);
@@ -33,6 +36,15 @@ CachedResource.prototype.get = function(callback) {
 };
 
 // PRIVATE
+
+var cacheKey = function() {
+  var parts = [
+    this.resource.requestUrl(),
+    JSON.stringify(_.omit(this.options.headers || {}, 'cache-control', 'Cache-control', 'Cache-Control', 'CACHE-CONTROL', 'pragma', 'Pragma', 'PRAGMA')),
+    JSON.stringify(_.pick(this.options.auth || {}, 'user', 'pass'))
+  ];
+  return parts.join('|');
+};
 
 var refreshCache = function(resource_response) {
   if (!resource_response.expired() || !resource_response.lock(this.options.timeout)) return;
@@ -61,7 +73,7 @@ var getAndCache = function(callback) {
         // The response has no cache headers, cache for a default duration
         resource_response.expires_at = new Date().getTime() + DEFAULT_RESOURCE_FRESHNESS;
       }
-      cache.set(self.resource.key(), resource_response);
+      cache.set(self.cache_key, resource_response);
     }
 
     callback(err, resource_response);

--- a/lib/page.js
+++ b/lib/page.js
@@ -13,7 +13,7 @@ var _ = require('underscore');
 var async = require('async');
 
 var CachedResource = require('./cached_resource.js');
-var routing = require('./routing.js');
+var utils = require('./utils.js');
 
 // rounds datetime to nearest 5 minutes (in the past)
 var getRoundedTime = function( datetime, round_by ){
@@ -43,7 +43,7 @@ var Page = function( page_path, options ){
     var route = this.relative_path.replace( /\.[a-z0-9]+$/i, '' ).replace( /\\/g, '/' );
     var route = '/'+ route;
     route = route.replace( '/index', '' ); // replace indexes with base routes
-    route = routing.formatRouteForExpress(route);
+    route = utils.formatRouteForExpress(route);
     if( route === '' ) route = '/';
     page.route = route;
 
@@ -165,14 +165,14 @@ var Page = function( page_path, options ){
   };
 
   // fetches remote resources
-  this.fetchResources = function( context, iterator, callback ){
+  this.fetchResources = function( req, context, iterator, callback ){
 
     var page = this;
 
     if( page.params.resources ){
       // convert resources object into array
       var resources_array = _( page.params.resources ).map( function( options, name ){
-        var resource = new CachedResource(options, server.auth, context.parameters, server.logger);
+        var resource = new CachedResource(server.resourceOptions(req, options), server.auth, context.parameters, server.logger);
         resource.name = name;
         return resource;
       });
@@ -300,7 +300,8 @@ var Page = function( page_path, options ){
         styles: '<link rel="stylesheet" href="/compiled/styles.css" />'
       },
       layout: this.getLayout(),
-      is_preview: !!req.query.is_preview
+      is_preview: !!req.query.is_preview,
+      no_cache: req.no_cache
     };
     context = _( context ).defaults( router.locals );
 
@@ -316,18 +317,12 @@ var Page = function( page_path, options ){
       server.logger.log(page.route + ' [' + status + '] served in ' + (new Date - start_serve) +'ms', !err || status == 404 ? 3 : 0);
 
       res.status(status);
-      if (!server.options.dev) {
-        res.set({
-          'Cache-Control': 'public, max-age='+ ( 60 * 5 ),
-          'Expires': new Date( Date.now() + EXPIRY_TIME ).toUTCString(),
-          'Last-Modified': getRoundedTime( Date.now(), MODIFIED_ROUND_TIME ).toUTCString()
-        });
-      }
-      if (context.is_preview) {
-        res.set({
-          'X-Robots-Tag': 'noindex, nofollow'
-        });
-      }
+      res.set(server.responseCacheHeaders(req, {
+        max_age: 60 * 5,
+        expires: new Date(Date.now() + EXPIRY_TIME),
+        last_modified: getRoundedTime(Date.now(), MODIFIED_ROUND_TIME)
+      }));
+
       if (err) {
         err.redirect_url ? res.redirect(status, err.redirect_url) : renderErrorPage(err, context);
       } else {
@@ -360,7 +355,7 @@ var Page = function( page_path, options ){
     };
 
     var start_resources = new Date;
-    this.fetchResources( context,
+    this.fetchResources( req, context,
       function(resource, resource_response) {
         context.resources[resource.name] = resource_response.data;
       },

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -5,7 +5,7 @@ var path = require('path');
 var _ = require('underscore');
 var moment = require('moment');
 
-var routing = require('./routing.js');
+var utils = require('./utils.js');
 
 var Redirect = function( redirect_data, options ){
 
@@ -29,7 +29,7 @@ var Redirect = function( redirect_data, options ){
       this.route = from;
     } else {
       this.route = path.normalize( from ).replace( /\\/g, '/' );
-      this.route = routing.formatRouteForExpress(this.route);
+      this.route = utils.formatRouteForExpress(this.route);
     }
 
     router.get( this.route, function( req, res, next ){
@@ -38,7 +38,7 @@ var Redirect = function( redirect_data, options ){
       // if redirect is expired or premature skip it
       if( !expired && !premature ){
         var url = typeof(to) == 'function' ? to(req.params) : to;
-        res.redirect( status, routing.expandVariables(url, req.params) );
+        res.redirect( status, utils.expandVariables(url, req.params) );
       }
       else {
         next();

--- a/lib/server.js
+++ b/lib/server.js
@@ -41,6 +41,7 @@ var Preprocessor = require('./preprocessor.js');
 var Redirect = require('./redirect.js');
 var Logger = require('./logger.js');
 var CachedResource = require('./cached_resource.js');
+var utils = require('./utils.js');
 
 // make the path into a Windows compatible path
 var deGlobifyPath = function( file_path ){
@@ -124,6 +125,9 @@ var SolidusServer = function( options ){
     maxAge: options.assets_max_age
   }));
   router.use(function(req, res, next) {
+    // Detect no-cache mode
+    req.no_cache = utils.hasNoCacheHeader(req.headers);
+
     // Set unique id to current request, for logging purposes
     solidus_server.session.bindEmitter(req);
     solidus_server.session.bindEmitter(res);
@@ -177,6 +181,30 @@ var SolidusServer = function( options ){
     var partial_path = path.join(this.paths.views, partial_name + '.' + DEFAULT_VIEW_EXTENSION);
     if (!this.views[partial_path]) partial_path = path.join(this.paths.extra_partials, partial_name + '.' + DEFAULT_VIEW_EXTENSION);
     return partial_path;
+  };
+
+  this.responseCacheHeaders = function(req, options) {
+    var headers = {};
+    if (this.options.dev || req.query.is_preview) {
+      headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate';
+      headers['X-Robots-Tag'] = 'noindex, nofollow';
+    } else {
+      if (_.isNumber(options.max_age)) headers['Cache-Control'] = 'public, max-age=' + options.max_age;
+      if (_.isDate(options.expires)) headers['Expires'] = options.expires.toUTCString();
+      if (_.isDate(options.last_modified)) headers['Last-Modified'] = options.last_modified.toUTCString();
+    }
+    return headers;
+  };
+
+  this.resourceOptions = function(req, options) {
+    var opts = _.extend({}, _.isString(options) ? {url: options} : options);
+    if (req.no_cache) {
+      // Enable end-to-end reload, see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.4
+      opts.headers || (opts.headers = {});
+      opts.headers['Cache-Control'] = 'no-cache';
+      opts.headers['Pragma'] = 'no-cache';
+    }
+    return opts;
   };
 
   // adds a new page
@@ -328,15 +356,15 @@ var SolidusServer = function( options ){
     var self = this;
     this.router.get(this.options.api_route + 'resource.json', function(req, res) {
       if (!req.query.url) return res.json(400, {error: "Missing 'url' parameter"});
-      var cached_resource = new CachedResource(req.query, solidus_server.auth, {}, solidus_server.logger);
+      var cached_resource = new CachedResource(solidus_server.resourceOptions(req, req.query), solidus_server.auth, {}, solidus_server.logger);
       if (!cached_resource.resource.url) return res.json(400, {error: "Invalid 'url' parameter"});
 
       cached_resource.get(function(err, resource_response) {
-        if (resource_response && !self.options.dev) {
-          res.set({
-            'Cache-Control': 'public, max-age=' + resource_response.maxAge(),
-            'Expires': new Date(resource_response.expires_at).toUTCString()
-          });
+        if (resource_response) {
+          res.set(solidus_server.responseCacheHeaders(req, {
+            max_age: resource_response.maxAge(),
+            expires: new Date(resource_response.expires_at)
+          }));
         }
         if (err) {
           res.json(400, {status: 400, error: err.message, message: err});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,3 +9,9 @@ module.exports.expandVariables = function(string, params) {
     return params[capture] || '';
   });
 };
+
+// Checks if the headers contain a "no-cache" directive
+module.exports.hasNoCacheHeader = function(headers) {
+  var header = headers && (headers['cache-control'] || headers['Cache-Control'] || headers['CACHE-CONTROL'] || headers['pragma'] || headers['Pragma'] || headers['PRAGMA']);
+  return /no-cache($|[^=])/.test(header);
+};

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "raven": "^0.6.2",
     "socket.io": "~1.0.6",
     "continuation-local-storage": "~3.1.1",
-    "solidus-client": "^1.2.0",
+    "solidus-client": "^1.3.3",
     "browserify-transform-tools": "~1.2.1"
   },
   "devDependencies": {

--- a/test/fixtures/site 1/views/no-cache.hbs
+++ b/test/fixtures/site 1/views/no-cache.hbs
@@ -1,0 +1,18 @@
+{{!
+{
+  "title": "no-cache",
+  "resources": {
+    "cache1": {
+      "url": "https://solid.us/cache",
+      "query": {"a": 1},
+      "headers": {"Cache-Control": "no-cache"}
+    },
+    "cache2": {
+      "url": "https://solid.us/cache",
+      "query": {"a": 2}
+    }
+  }
+}
+}}
+
+Site 1 no-cache


### PR DESCRIPTION
Fixes #133

Solidus' resource cache is great to speed up pages for general users, but seriously slows down testing and publishing new content. ~~This pull request introduces a new "no-cache mode" to fix this problem. The mode is enabled when the first subdomain of the host is `preview` (by default, configurable with the `no_cache_subdomain` option). This means a production site can be hosted and browsed normally on `domain.com` or `abc.domain.com`, and its no-cache version will be accessible through `preview.domain.com` or `preview.abc.domain.com`.~~ This pull request makes Solidus follow the `no-cache` request headers, which are sent when a user forces-refresh a page in his browser.

When the `Cache-Control: no-cache` request is detected, the following changes happen to the request:
 - The `Cache-Control: no-cache` and `Pragma: no-cache` request HTTP headers are added to all resources. This enables the [end-to-end reload](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.4) of the resources from the proxies and APIs.
 - The resources cache is skipped, in order to get fresh data from the APIs. The resources cache is still updated with the fresh data, so normal requests can benefit from it.
 - ~~The response HTTP headers are set to disable the caching and indexation of the response: `Cache-Control: no-cache, no-store, max-age=0, must-revalidate` and `X-Robots-Tag: noindex, nofollow`.~~