### PR TITLE
Docker native

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -396,8 +396,7 @@ var SolidusServer = function( options ){
 
         return false;
       },
-      ignoreInitial: true,
-      interval: 1000
+      ignoreInitial: true
     });
 
     watcher.on( 'add', function( file_path ){

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sugar": "~1.3.8",
     "xdate": "~0.8.0",
     "moment": "~2.0.0",
-    "chokidar": "~0.6.2",
+    "chokidar": "^1.6.0",
     "connect": "~2.8.4",
     "hyperquest": "~0.1.7",
     "lru-cache": "~2.3.1",

--- a/test/solidus.js
+++ b/test/solidus.js
@@ -1,5 +1,5 @@
 const DEFAULT_ENCODING = 'UTF8';
-const FILESYSTEM_DELAY = 1100;
+const FILESYSTEM_DELAY = 150;
 
 var path = require('path');
 var assert = require('assert');


### PR DESCRIPTION
Polling file changes in the new Docker native [is really CPU intensive](https://forums.docker.com/t/com-docker-hyperkit-up-cpu-to-340/13057). Use the latest [chokidar](https://github.com/paulmillr/chokidar), which stopped using polling by default [a long time ago](https://github.com/paulmillr/chokidar/blob/master/CHANGELOG.md#chokidar-080-nov-29-2013).
