### PR TITLE
Render complex error page properly

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -317,6 +317,7 @@ var Page = function( page_path, options ){
 
     // actually render the page
     var renderPage = function(err, context) {
+      err = err || options.err;
       var status = err ? err.status : 200;
       server.logger.log(page.route + ' [' + status + '] served in ' + (new Date - start_serve) +'ms', !err || status == 404 ? 3 : 0);
 
@@ -335,6 +336,7 @@ var Page = function( page_path, options ){
 
     var renderErrorPage = function(err, context) {
       context = context || {};
+      context.helpers = server.site_helpers;
       context.error = err;
       if (options.json) {
         res.json(context);

--- a/lib/server.js
+++ b/lib/server.js
@@ -148,12 +148,11 @@ var SolidusServer = function( options ){
   }
   // catch-all middleware at the end of the stack for 404 handling
   router.use( function( req, res, next ){
-    res.status( 404 );
-    // it's cheaper to check this than to fs.exists the error path
     if( views[paths.error] ){
-      res.render(paths.error, {error: {status: 404, error: http.STATUS_CODES[404], message: http.STATUS_CODES[404]}});
+      views[paths.error].render(req, res, {err: {status: 404, error: http.STATUS_CODES[404], message: http.STATUS_CODES[404]}});
     }
     else {
+      res.status( 404 );
       res.send('404 ' + http.STATUS_CODES[404]);
     }
   });

--- a/test/fixtures/site 1/views/error.hbs
+++ b/test/fixtures/site 1/views/error.hbs
@@ -1,5 +1,14 @@
+{{!
+{
+  "title": "Error title"
+}
+}}
+
 {{# equal error.status 404 }}
   Not here!
 {{ else }}
   Oh no ({{ error.status }})!
 {{/ equal }}
+
+{{! Site helper }}
+{{frenchify test_string}}

--- a/test/fixtures/site 1/views/layout.hbs
+++ b/test/fixtures/site 1/views/layout.hbs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{{title}}</title>
+    <title>{{page.title}}</title>
   </head>
   <body>
     {{{body}}}

--- a/test/fixtures/site 1/views/with_preprocessor_error.hbs
+++ b/test/fixtures/site 1/views/with_preprocessor_error.hbs
@@ -1,5 +1,6 @@
 {{!
 {
+  "title": "Original title",
   "preprocessor": "error.js"
 }
 }}


### PR DESCRIPTION
The special `error.hbs` file will most likely use a site's complex layout, which could expect to have all the fancy features that other pages have, like a full context, helpers, etc.

This PR fully renders the error page like any other page, instead of just rendering the template with an empty context.

Side effect: each `error` render is logged, but that only happens in dev...

```
[2016-10-12T16:05:57.915Z] 1 /error resources fetched in 0ms
[2016-10-12T16:05:58.218Z] 1 /error preprocessed in 303ms
[2016-10-12T16:05:58.218Z] 1 /error [404] served in 306ms
```