### PR TITLE
Return 500 instead of status error

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -178,7 +178,7 @@ var Page = function( page_path, options ){
       async.each( resources_array, function( resource, cb ){
         resource.get(function(err, resource_response) {
           if (err) {
-            var status = err.status || 500;
+            var status = err.status == 404 ? 404 : 500;
             var error  = 'Resource error: ' + err.message;
             var is_optional = context.is_preview || resource.options.optional;
 

--- a/test/solidus.js
+++ b/test/solidus.js
@@ -322,9 +322,21 @@ describe( 'Solidus', function(){
           nock('https://solid.us').get('/error/mandatory?test=3').reply(401, {error: 'Nice try'});
           nock('https://solid.us').get('/error/optional?test=3').reply(200, {test: 3});
           s_request.get('/with_resource_error?test=3')
-            .expect(401)
+            .expect(500)
             .end(function(err, res) {
-              assert(res.text.indexOf('Oh no (401)!') > -1);
+              assert(res.text.indexOf('Oh no (500)!') > -1);
+              callback(err);
+            });
+        },
+        function(callback) {
+          // Bad status is available in context
+          nock('https://solid.us').get('/error/mandatory?test=3').reply(401, {error: 'Nice try'});
+          nock('https://solid.us').get('/error/optional?test=3').reply(200, {test: 3});
+          s_request.get('/with_resource_error.json?test=3')
+            .expect(500)
+            .end(function(err, res) {
+              assert.equal(res.body.error.status, 500);
+              assert.equal(res.body.error.message.status, 401);
               callback(err);
             });
         },
@@ -1219,9 +1231,9 @@ describe( 'Solidus', function(){
           nock('https://solid.us').get('/error/mandatory?test=3').reply(401, {error: 'Nice try'});
           nock('https://solid.us').get('/error/optional?test=3').reply(200, {test: 3});
           s_request.get('/with_resource_error?test=3')
-            .expect(401)
+            .expect(500)
             .end(function(err, res) {
-              assert.equal(res.text, '401 Unauthorized');
+              assert.equal(res.text, '500 Internal Server Error');
               callback(err);
             });
         }


### PR DESCRIPTION
When a resource returns an error code, other than 404, the page should be rendered with a 500 code instead of the resource's code. It doesn't really make sense to tell the client he's unauthorized to access a page that uses an unauthorized resource.